### PR TITLE
Fix README.md note section at line 63

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ It really looks like the default menu, isn't it?
 But it's rendering procedure is completely different from the defualt one, making TranslucentFlyout hard to modify its visual content.  
 #### **3. StartAllBack**
 `StartAllBack` has built-in support for translucent popup menu, and its rendering procedure priority is higher than TranslucentFlyouts.  
-> [Note!]:  
+> [!Note]:  
 > For this reason, `v2.0.0-alpha.4` and higher versions of TranslucentFlyouts will automatically disable itself when `StartAllBack` was detected, unless there is a way to fully disable `StartAllBack`' s handling procedure.  
 > However, TranslucentFlyouts is still available for other applications except `Explorer`.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Windows 11
 2. Unzip it to a location such as "`C:\Program Files`".
 3. Run "`install.cmd`" as administrator.
 
-> [Note!]:   
+> [!Note]:   
 > **Downloading symbol files from Microsoft server is required at the first time or after a windows update, otherwise some functionalities will be unavailable!**  
 
 ### Uninstall


### PR DESCRIPTION
## Example to show the functionality in README.md:

> [!Note]
> lorem ~~~~~~~~~~~~~ Uses ([!Note]) Without round brackets.

> [!Important]
> Lorem ~~~~ Uses ([!Important]) Without round brackets or parentheses.

> [!Warning]
> Uses ([!Warning]) Without round brackets or parentheses.

Credit: Satanarious's v1.4.0 release page. He has a little note section for which I set out for the search that what's the code behind it. And then I just was roaming around his README, and I knew the code! Then why did I come to your repo? It's because I wanted to download the latest release of TF! And then found the code that was broken.

> [!Note]
> There might be more of them!